### PR TITLE
Remove old admin-lookup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ See [the config](https://github.com/pelias/config) documentation for details on 
 ```javascript
   "imports": {
     "polyline": {
-      "adminLookup": true,
       "datapath": "/data",
       "files": [ "road_network.polylines" ]
     }


### PR DESCRIPTION
Option was removed a while ago so it shouldn't show up in the example https://github.com/pelias/config/pull/52