### PR TITLE
Increase Node.js memory limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "start": "node bin/cli.js --config --db",
+    "start": "node --max_old_space_size=4096 bin/cli.js --config --db",
     "dry-run": "node bin/cli.js --config --pretty",
     "test": "PELIAS_CONFIG=test/pelias.test.config.json node test/run.js | tap-spec",
     "travis": "npm run check-dependencies && npm test",


### PR DESCRIPTION
The admin lookup worker processes are starting to hit the default memory
limit. Increasing it gives us time to improve the admin lookup
architecture.

Connected to https://github.com/pelias/wof-admin-lookup/issues/117