### PR TITLE
Remove install of gcc 4.8 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,10 @@ node_js:
   - 6
 matrix:
   fast_finish: true
-env:
-  global:
-    - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 script: npm run travis
+before_install:
+  - npm i -g npm@^3.0.0
 before_script:
   - npm prune
 after_success:
-  - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
-  - python travis_after_all.py
-  - export $(cat .to_export_back) &> /dev/null
   - npm run semantic-release


### PR DESCRIPTION
Now that TravisCI [defaults to Ubuntu 14](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status), we no longer need to install a newer version of GCC in our Travis builds.

This installation process can take up to 2 minutes (and our builds are usually under 4 minutes), meaning this change makes Travis run twice as fast!!

Connects pelias/pelias#575