### PR TITLE
improved error checking, add warning for large PBF extracts

### DIFF
--- a/docker_extract.sh
+++ b/docker_extract.sh
@@ -4,8 +4,27 @@ set -euo pipefail
 # ensure data subdirectory exists
 mkdir -p /data/polylines/;
 
-# extract the first pbf file found in the osm directory
-ls -1 /data/openstreetmap/*.osm.pbf | head -n1 | xargs pbf streets > /data/polylines/extract.0sv;
+# find the first pbf file in the osm directory
+PBF_FILE=$(ls -1 /data/openstreetmap/*.pbf || true | head -n1);
+if [ -z "${PBF_FILE}" ]; then
+  2>&1 echo 'no *.pbf files found in /data/openstreetmap directory';
+  exit 1;
+fi
+
+# give a warning if the filesize is over 1GB
+# the missinglink/pbf library is memory-bound and cannot safely handle very large extracts
+find "${PBF_FILE}" -maxdepth 1 -size +1G | while read file; do
+  2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+  2>&1 echo "${PBF_FILE} is very large.";
+  2>&1 echo 'You will likely experience memory issues working with large extracts like this.';
+  2>&1 echo 'We strongly recommend using Valhalla to produce extracts for large PBF extracts.';
+  2>&1 echo 'see: https://github.com/pelias/polylines#download!data';
+  2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+done
+
+# convert pbf file to 0sv (polylines) format
+echo "converting ${PBF_FILE} to /data/polylines/extract.0sv";
+pbf streets "${PBF_FILE}" > /data/polylines/extract.0sv;
 
 # debugging info
 echo 'wrote polylines extract';


### PR DESCRIPTION
@orangejulius I've seen a few reports coming through about `missinglink/pbf` running out of memory when run on large extracts.

unfortunately, this is by design and it's intended that the Valhalla extract method is used for larger extract.

that's not very clear when using the docker setup because it bundles `missinglink/pbf` in with this code.

merging this will have two benefits:
- it will bring in the memory optimizations from https://github.com/missinglink/pbf/pull/15 which AFAIK haven't been released in a `latest` image for 
 this repo yet (22 days vs. 18 days)
- it will spit out a very ugly warning message if the extract is over 1GB (we can change this constant), so that it will be in the logs just before any out-of-memory error is printed.