### PR TITLE
feat(test): Use dedicated test script to catch errors

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+NODE_ENV=test PELIAS_CONFIG=test/pelias.test.config.json node test/run.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node --max_old_space_size=4096 bin/cli.js --config --db",
     "dry-run": "node bin/cli.js --config --pretty",
-    "test": "NODE_ENV=test PELIAS_CONFIG=test/pelias.test.config.json node test/run.js | tap-spec",
+    "test": "./bin/test",
     "travis": "npm test",
     "lint": "jshint .",
     "validate": "npm ls"


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in
the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail`
option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744