### PR TITLE
Support read-only root fs when running in Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,12 @@ ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
 # get go dependencies
 RUN go get github.com/missinglink/pbf
 
+# copy package.json first to prevent npm install being rerun when only code changes
+COPY ./package.json ${WORKDIR}
+RUN npm install
+
 # copy code into image
 ADD . ${WORKDIR}
-
-# install npm dependencies
-RUN npm install
 
 # run tests
 RUN npm test

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node --max_old_space_size=4096 bin/cli.js --config --db

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "start": "node --max_old_space_size=4096 bin/cli.js --config --db",
+    "start": "./bin/start",
     "dry-run": "node bin/cli.js --config --pretty",
     "test": "./bin/test",
     "travis": "npm test",


### PR DESCRIPTION
By using a dedicated start script instead of `npm start` when running Docker images, we can avoid issues with passing signals through to the underlying processes.

This also avoids issues with `npm` requiring write permissions to the root filesystem.

This PR also changes the Dockerfile to ensure repeated local Docker builds are speed up by avoiding extra runs of `npm install` when not needed.

Connects https://github.com/pelias/pelias/issues/745