### PR TITLE
docker_extract.sh support for multiple PBF files

### DIFF
--- a/docker_extract.sh
+++ b/docker_extract.sh
@@ -4,27 +4,37 @@ set -euo pipefail
 # ensure data subdirectory exists
 mkdir -p /data/polylines/;
 
-# find the first pbf file in the osm directory
-PBF_FILE=$(ls -1 /data/openstreetmap/*.pbf || true | head -n1);
-if [ -z "${PBF_FILE}" ]; then
+# enumerate a list of PBF files
+PBF_FILES=($((ls -1 /data/openstreetmap/*.pbf || true) >/dev/null 2>&1));
+
+# ensure there is at least one PBF file in the osm directory
+if [ ${#PBF_FILES[@]} -eq 0 ]; then
   2>&1 echo 'no *.pbf files found in /data/openstreetmap directory';
   exit 1;
 fi
 
-# give a warning if the filesize is over 1GB
-# the missinglink/pbf library is memory-bound and cannot safely handle very large extracts
-find "${PBF_FILE}" -maxdepth 1 -size +1G | while read file; do
-  2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
-  2>&1 echo "${PBF_FILE} is very large.";
-  2>&1 echo 'You will likely experience memory issues working with large extracts like this.';
-  2>&1 echo 'We strongly recommend using Valhalla to produce extracts for large PBF extracts.';
-  2>&1 echo 'see: https://github.com/pelias/polylines#download!data';
-  2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
-done
+# truncate polylines file
+echo '' > /data/polylines/extract.0sv;
 
-# convert pbf file to 0sv (polylines) format
-echo "converting ${PBF_FILE} to /data/polylines/extract.0sv";
-pbf streets "${PBF_FILE}" > /data/polylines/extract.0sv;
+# iterate over all PBF files in the osm directory
+for PBF_FILE in "${PBF_FILES[@]}"; do
+
+  # give a warning if the filesize is over 1GB
+  # the missinglink/pbf library is memory-bound and cannot safely handle very large extracts
+  find "${PBF_FILE}" -maxdepth 1 -size +1G | while read file; do
+    2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+    2>&1 echo "${PBF_FILE} is very large.";
+    2>&1 echo 'You will likely experience memory issues working with large extracts like this.';
+    2>&1 echo 'We strongly recommend using Valhalla to produce extracts for large PBF extracts.';
+    2>&1 echo 'see: https://github.com/pelias/polylines#download!data';
+    2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+  done
+
+  # convert pbf file to 0sv (polylines) format, appending results to polyline file
+  echo "converting ${PBF_FILE} to /data/polylines/extract.0sv";
+  pbf streets "${PBF_FILE}" >> /data/polylines/extract.0sv;
+
+done
 
 # debugging info
 echo 'wrote polylines extract';


### PR DESCRIPTION
I just discovered https://github.com/pelias/polylines/issues/201 and Instead of just fixing that as-is I figured, why not support multiple PBF files?

I'm not sure why we decided to only extract the first OSM PBF file found in the directory.

This PR fixes 201, meaning that users who had multiple PBF files listed in their pelias.json would suffer a failed interpolation build and presumably street import too.

With this PR all the streets are imported into both ES and Interpolation.

resolves https://github.com/pelias/polylines/issues/201