### PR TITLE
fix(docker_extract): detect files without using ls

### DIFF
--- a/docker_extract.sh
+++ b/docker_extract.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 mkdir -p /data/polylines/;
 
 # enumerate a list of PBF files
-PBF_FILES=($((ls -1 /data/openstreetmap/*.pbf || true) >/dev/null 2>&1));
+shopt -s nullglob
+PBF_FILES=(/data/openstreetmap/*.pbf);
 
 # ensure there is at least one PBF file in the osm directory
-if [ ${#PBF_FILES[@]} -eq 0 ]; then
+if [[ ${#PBF_FILES[@]} -eq 0 ]]; then
   2>&1 echo 'no *.pbf files found in /data/openstreetmap directory';
   exit 1;
 fi


### PR DESCRIPTION
Using [ls for detecting files is problematic](https://mywiki.wooledge.org/ParsingLs), and in my case, running `pelias prepare polylines` did not detect my PBF file.

It turns out that using file globbing is quite simple for this, and works well.