### PR TITLE
feat(logger): Use dbclient name functionality

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -59,7 +59,7 @@ else if( tty.isatty( process.stdin ) ){
 var input = argv.file ? fs.createReadStream( argv.file ) : process.stdin;
 
 // write to stdout or elasticsearch
-var output = !!argv.db ? dbclient() : stringify;
+var output = !!argv.db ? dbclient({name: 'polylines'}) : stringify;
 
 // run the importer
 pipeline( input, output );

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "geojson-extent": "^0.3.2",
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",
-    "pelias-dbclient": "^2.5.6",
+    "pelias-dbclient": "^2.8.0",
     "pelias-config": "^3.0.2",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^5.5.2",


### PR DESCRIPTION
This allows distinguishing which logger output lines correspond to which importer during an import.

Connects https://github.com/pelias/dbclient/issues/101