### PR TITLE
documentation related to polyline precision 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,37 @@ Once you have downloaded and extracted the data you will need to follow the *Con
 
 If you would like to use a different source of polyline data you might need to tweak the defaults in `./stream/pipeline.js`, open an issue if you get stuck.
 
+## Generating your own data
+
+You can generate a polylines file from your own data, the data MUST be encoded in the following format:
+
+- each row of the file represents one document, rows are terminated with a newline (`\n`) character.
+- rows contain multiple columns, columns are delimited with a null byte (`\0`) character.
+
+The geometry is encoded using the [Google polyline algorithm](https://developers.google.com/maps/documentation/utilities/polylinealgorithm) at a precision of `6`.
+
+NOTE: many libraries will default the precision to `5`, this will cause errors, be sure to select the correct [polyline precision](https://www.mapzen.com/blog/polyline-precision/).
+
+There is a script included in this repo which is capable of re-encoding files generated with precison `5` to precision `6`, you can find it in `bin/reencode.js`.
+
+Each row begins with the encoded polyline, followed by a null byte (`\0`) then followed by one or more names (delimited with a null byte) and finally terminated with a newline (`\n`).
+
+Example:
+
+```
+{polyline6}\0{name}\0{name}\n
+```
+
+```
+oozdnAwvbsBoA?g@{@SoAf@{@nAg@Plaça de la Creu
+```
+
+```
+00000000: 6f6f 7a64 6e41 7776 6273 426f 413f 6740  oozdnAwvbsBoA?g@
+00000010: 7b40 536f 4166 407b 406e 4167 4000 506c  {@SoAf@{@nAg@.Pl
+00000020: 61c3 a761 2064 6520 6c61 2043 7265 750a  a..a de la Creu.
+```
+
 ## Configuration
 
 In order to tell the importer the location of your downloads and environmental settings you will first need to create a `~/pelias.json` file.

--- a/bin/reencode.js
+++ b/bin/reencode.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * re-encode a polyline file generated with precison 5 to precision 6
+ */
+
+const fs = require('fs');
+const tty = require('tty');
+const through = require('through2');
+const argv = require('minimist')(process.argv.slice(2));
+const polyline = require('polyline');
+const split = require('split');
+const precision = { from: 5, to: 6 };
+
+// cli help
+if (argv.help) {
+  console.error('Usage: reencode.js [options]\nOptions:\n');
+  console.error('  --file           read from file instead of stdin');
+  process.exit(0);
+}
+
+// check file exists
+if (!!argv.file) {
+  try { fs.lstatSync(argv.file); }
+  catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+}
+
+// input is from stdin and it's attached to TTY instead of a pipe
+else if (tty.isatty(process.stdin)) {
+  console.error('no data piped to stdin');
+  process.exit(1);
+}
+
+// read from stdin or file
+var input = argv.file ? fs.createReadStream(argv.file) : process.stdin;
+
+return input
+  .pipe(split())
+  .pipe(through.obj((row, _, next) => {
+    let cols = row.split('\0');
+    if (cols.length < 2) { console.error( 'invalid polyline row', row ); }
+
+    let decoded = polyline.decode(cols[0], precision.from);
+    let encoded = polyline.encode(decoded, precision.to);
+
+    console.log([encoded].concat(cols.slice(1)).join('\0'));
+    next();
+  }));


### PR DESCRIPTION
There was inadequate documentation for our use of polyline precision 6.
In many libraries the default precision value is 5, which is incompatible with our code.

see: https://www.mapzen.com/blog/polyline-precision/ for background info.

- add convenience script to re-encode polylines generated at precision 5 to precision 6
- add documentation to README