### PR TITLE
empty polylines file

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "pelias-logger": "^1.2.1",
     "pelias-model": "^7.1.0",
     "pelias-wof-admin-lookup": "^6.0.0",
-    "split": "^1.0.0",
+    "split2": "^3.1.1",
     "through2": "^3.0.0"
   },
   "devDependencies": {

--- a/stream/pipeline.js
+++ b/stream/pipeline.js
@@ -1,12 +1,10 @@
-
-var split = require('split'),
-    through = require('through2'),
-    model = require('pelias-model'),
-    parser = require('./parser'),
-    unwrap = require('./unwrap'),
-    centroid = require('./centroid'),
-    document = require('./document'),
-    adminLookup = require('pelias-wof-admin-lookup').create;
+const split = require('split2');
+const model = require('pelias-model');
+const parser = require('./parser');
+const unwrap = require('./unwrap');
+const centroid = require('./centroid');
+const document = require('./document');
+const adminLookup = require('pelias-wof-admin-lookup').create;
 
 function pipeline( streamIn, streamOut ){
   return streamIn


### PR DESCRIPTION
resolves https://github.com/pelias/polylines/issues/245

- update `wof-admin-lookup` to `6.5.1` which handles termination of workers when the input file is empty
- some minor code aesthetics to trigger a build: use split2 module, modernize require statements

When a polylines import references an empty file, it will now exit with the following log messages:

```bash
2020-03-18T09:43:01.423Z - info: [wof-admin-lookup] Shutting down admin lookup service
2020-03-18T09:43:01.423Z - info: [wof-admin-lookup] Ensure your input file is valid before retrying
```