### PR TITLE
change missinglink/pbf warning to fatal error

### DIFF
--- a/docker_extract.sh
+++ b/docker_extract.sh
@@ -25,10 +25,11 @@ for PBF_FILE in "${PBF_FILES[@]}"; do
   find "${PBF_FILE}" -maxdepth 1 -size +1G | while read file; do
     2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
     2>&1 echo "${PBF_FILE} is very large.";
-    2>&1 echo 'You will likely experience memory issues working with large extracts like this.';
     2>&1 echo 'We strongly recommend using Valhalla to produce extracts for large PBF extracts.';
-    2>&1 echo 'see: https://github.com/pelias/polylines#download!data';
+    2>&1 echo 'You can also download pre-processed polyline extracts from Geocode Earth.';
+    2>&1 echo 'see: https://github.com/pelias/polylines#download-data';
     2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+    exit 1
   done
 
   # convert pbf file to 0sv (polylines) format, appending results to polyline file


### PR DESCRIPTION
By default, the algorithm to generate polyline data from a PBF file is the `pbf streets` command from my https://github.com/missinglink/pbf repo.

This algorithm is memory-bound and so doesn't scale well past a city or small country on modest hardware.
I made some attempts in the past to [spit out a very ugly warning message](https://github.com/pelias/polylines/pull/167), but this warning is easy to miss.

Recently https://github.com/pelias/polylines/issues/245 highlighted that even 125GB RAM is insufficient for the `pbf streets` command to process the whole planet.

As such **I'm going to turn this warning into a fatal error**.

The current upper limit for a PBF file is 1GB, which I'm open to changing if it's shown that the `pbf streets` is able to handle larger PBF files on modest hardware (8-16GB RAM).

Users who wish to work on larger extracts such as `North America` or `Planet` have three options:
- Download the [pre-processed planet files](https://github.com/pelias/polylines#download-data) from Geocode Earth
- Generate their own polylines extract using [Valhalla](https://github.com/valhalla)
- Generate their own polylines extract using any tool which [generates the required format](https://github.com/pelias/polylines/blob/master/stream/parser.js#L6) (note: `precision=6` is the default).

The `planet-latest-valhalla.polylines.0sv.gz` file on the Geocode Earth data download page is almost a year old, I'll go ahead and update that file now so that anyone affected by this has fresh data to work with.

If you elect to download the data from Geocode Earth then you can simply skip the `pelias prepare polylines` step.
If you're using `pelias prepare all` then you'll need to replace that `all` step with multiple `prepare` steps which cover all other prepare operations other than `prepare polylines`.