### PR TITLE
upgrade Golang version and set GO111MODULE=on

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
 # base image
 FROM pelias/baseimage
 
-# install go 1.10
-ENV GOPATH=/usr/src/.go
-RUN wget -qO- https://dl.google.com/go/go1.10.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-RUN mkdir -p "${GOPATH}"
-ENV PATH="${PATH}:/usr/local/go/bin:${GOPATH}/bin"
-
 # change working dir
 ENV WORKDIR /code/pelias/polylines
 WORKDIR ${WORKDIR}
 
-# configure go environment
-ENV GOPATH $HOME/go
-ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+# install Golang
+ENV GOPATH=/usr/src/.go
+RUN wget -qO- https://golang.org/dl/go1.15.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN mkdir -p "${GOPATH}"
+ENV PATH="${PATH}:/usr/local/go/bin:${GOPATH}/bin"
+ENV GO111MODULE=on
 
 # get go dependencies
 RUN go get github.com/missinglink/pbf


### PR DESCRIPTION
upgrade Golang version and set `GO111MODULE=on`

closes https://github.com/pelias/polylines/issues/256
see: https://dev.to/maelvls/why-is-go111module-everywhere-and-everything-about-go-modules-24k