### PR TITLE
Update "filesize is over 1GB" warning

### DIFF
--- a/docker_extract.sh
+++ b/docker_extract.sh
@@ -29,6 +29,9 @@ for PBF_FILE in "${PBF_FILES[@]}"; do
     2>&1 echo 'You can also download pre-processed polyline extracts from Geocode Earth.';
     2>&1 echo 'see: https://github.com/pelias/polylines#download-data';
     2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+    
+    echo "Generating polylines from ${PBF_FILE} failed! The file is too large.";
+    echo "Exiting...";
     exit 1
   done
 

--- a/docker_extract.sh
+++ b/docker_extract.sh
@@ -30,8 +30,8 @@ for PBF_FILE in "${PBF_FILES[@]}"; do
     2>&1 echo 'see: https://github.com/pelias/polylines#download-data';
     2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
     
-    echo "Generating polylines from ${PBF_FILE} failed! The file is too large.";
-    echo "Exiting...";
+    2>&1 echo "Generating polylines from ${PBF_FILE} failed! The file is too large.";
+    2>&1 echo "Exiting...";
     exit 1
   done
 


### PR DESCRIPTION
Make the message for the warning "filesize is over 1GB" more clear that the script will exit and no polylines will be generated.