### PR TITLE
Add explicit `gcc` dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN mkdir -p "${GOPATH}"
 ENV PATH="${PATH}:/usr/local/go/bin:${GOPATH}/bin"
 ENV GO111MODULE=on
 
-# get go dependencies
-RUN go get github.com/missinglink/pbf
+# get go dependencies, temporarily installing GCC
+RUN apt-get update && apt-get install -y gcc && go get github.com/missinglink/pbf && apt-get remove -y gcc && rm -rf /var/lib/apt/lists/*
 
 # copy package.json first to prevent npm install being rerun when only code changes
 COPY ./package.json ${WORKDIR}


### PR DESCRIPTION
In https://github.com/pelias/docker-baseimage/pull/23 we're leaning out our Docker baseimage used by all other Pelias images, and hopefully can remove the compiler toolchain all together.

The Polylines Docker images _do_ need `gcc` (but not quite a full compiler toolchain), but didn't follow the convention in our other Dockerfiles of having an `apt-get` step to install it.

This PR adds such a step, and is a little clever in installing `gcc` only temporarily, and only for the `go get` step that requires it.

The polylines Docker image is already quite large (950MB uncompressed) since it includes Node.js, Go, and package dependencies for both. Skipping the installation of `gcc` cuts out 120MB of that.

Until https://github.com/pelias/docker-baseimage/pull/23 this change won't really have any impact on the size or operation of this Docker image.