### PR TITLE
upgrade pelias-model to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pelias-config": "^4.12.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
-    "pelias-model": "^7.1.0",
+    "pelias-model": "^9.1.1",
     "pelias-wof-admin-lookup": "^7.0.0",
     "split2": "^3.1.1",
     "through2": "^3.0.0"


### PR DESCRIPTION
this PR upgrades `pelias/model` to the latest version.

looking through [the changelog](https://github.com/pelias/model/releases) there is nothing which will effect the Polylines importer, which is probably why we didn't do this sooner.