### PR TITLE
docs: go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Note: golang 1.9+ is required, please ensure this is correctly installed before 
 $ go version
 go version go1.10 linux/amd64
 
-$ go get github.com/missinglink/pbf
+$ go install github.com/missinglink/pbf@latest
 
 $ pbf --help
 


### PR DESCRIPTION
I replaced `go get` with `go install` as the execution of the first gave the following message:

'go get' is no longer supported outside a module. To build and install a command, use 'go install' with a version, like 'go install example.com/cmd@latest'.
