### PR TITLE
dockerfile: correctly select Go architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && apt-get install gcc -y
 
 # install Golang
 ENV GOPATH=/go
-RUN wget -qO- https://golang.org/dl/go1.15.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ARG TARGETPLATFORM
+RUN wget -qO- "https://golang.org/dl/go1.15.2.linux-${TARGETPLATFORM##*/}.tar.gz" | tar -C /usr/local -xzf -
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GO111MODULE=on
 


### PR DESCRIPTION
this PR detects the target architecture and selects the correct Golang download accordingly.

> note: the `TARGETPLATFORM` is something like `linux/arm64` and the `${TARGETPLATFORM##*/}` command selects everything after the last slash.